### PR TITLE
Fix irrecoverable fswalk exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,12 +69,16 @@ var walkSync = exports.walkSync = function(dir, iterator) {
         var files = fs.readdirSync(dir);
         files.forEach(function(file) {
             var f = path.join(dir, file);
-            var stat = fs.statSync(f);
-            if (stat && stat.isDirectory()) {
-                dirs.push(f);
-            }
-            if (stat) {
-                iterator(dir, file, stat);
+            try {
+                var stat = fs.statSync(f);
+                if (stat && stat.isDirectory()) {
+                    dirs.push(f);
+                }
+                if (stat) {
+                    iterator(dir, file, stat);
+                }
+            } catch (e) {
+              /* ignore exceptions here */
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fs-walk",
   "description": "Synchronous and asynchronous recursive directory listing for node",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository" : {
     "type" : "git",
     "url" : "https://github.com/confcompass/fs-walk.git"


### PR DESCRIPTION
Right now, fswalk-sync will throw an exception if a directory contains a symlink to a file that doesn't exist. This is not the desired behaviour because we will not be able to enumerate anything in that case.

The patch captures the exception and skips to the next path.
